### PR TITLE
check if np.inf exists (NumPy 2.0+) and use it instead of depricateted np.Infinity

### DIFF
--- a/notebook-widget/wizmap/wizmap.py
+++ b/notebook-widget/wizmap/wizmap.py
@@ -494,7 +494,9 @@ def select_topic_levels(
 
     while scale <= max_zoom_scale:
         best_level = 1
-        best_tile_width_diff = np.Infinity
+
+        # Check if 'np.inf' exists (NumPy 2.0+) and use it instead of deprecated 'np.Infinity'
+        best_tile_width_diff = np.inf if hasattr(np, "inf") else np.Infinity
 
         for l in range(1, 21):
             tile_num = 2**l


### PR DESCRIPTION
With numpy version 2.0+ using `wizmap.generate_grid_dict` throws such error:
```
  File "/my_cool_project/wizmap/.venv/lib/python3.13/site-packages/wizmap/wizmap.py", line 565, in generate_topic_dict
    min_level, max_level = select_topic_levels(
                           ~~~~~~~~~~~~~~~~~~~^
        max_zoom_scale,
        ^^^^^^^^^^^^^^^
    ...<5 lines>...
        ideal_tile_width,
        ^^^^^^^^^^^^^^^^^
    )
    ^
  File "/my_cool_project/wizmap/.venv/lib/python3.13/site-packages/wizmap/wizmap.py", line 497, in select_topic_levels
    best_tile_width_diff = np.Infinity
                           ^^^^^^^^^^^
  File "/my_cool_project/wizmap/.venv/lib/python3.13/site-packages/numpy/__init__.py", line 400, in __getattr__
    raise AttributeError(
    ...<3 lines>...
    )
AttributeError: `np.Infinity` was removed in the NumPy 2.0 release. Use `np.inf` instead.
```

That PR just adds check if `np.inf` is avaliable and uses it if so