### PR TITLE
Fix group names, change default to show all groups

### DIFF
--- a/src/components/embedding/Embedding.svelte
+++ b/src/components/embedding/Embedding.svelte
@@ -238,7 +238,7 @@
               class="checkbox"
               id="checkbox-contour-2"
               name="checkbox-contour-2"
-              checked="{false}"
+              checked="{defaultSetting.showContour}"
               on:input="{e =>
                 displayCheckboxChanged(
                   e,
@@ -319,7 +319,7 @@
               class="checkbox"
               id="checkbox-point-2"
               name="checkbox-point-2"
-              checked="{false}"
+              checked="{defaultSetting.showPoint}"
               on:input="{e =>
                 displayCheckboxChanged(e, 'point', myEmbedding?.groupNames[1])}"
             />

--- a/src/components/embedding/Embedding.ts
+++ b/src/components/embedding/Embedding.ts
@@ -634,16 +634,19 @@ export class Embedding {
 
       for (let i = 0; i < this.groupNames.length; i++) {
         // Add groups to the control states
-        // (Default is to show the first group only)
-        this.showContours.push(i === 0);
-        this.showPoints.push(i === 0);
+        // (Default is to show all groups)
+        this.showContours.push(true);
+        this.showPoints.push(true);
 
         // Add contour elements for other groups
         const name = this.groupNames[i];
         umapGroup
           .append('g')
-          .attr('class', `contour-group-generic contour-group-${name}`)
-          .classed('hidden', i !== 0);
+          .attr(
+            'class',
+            `contour-group-generic contour-group-${getCSSSafeName(name)}`
+          )
+          .classed('hidden', false);
 
         // Drw the group contour
         const curContour = this.drawGroupContour(name);
@@ -901,7 +904,7 @@ export class Embedding {
     }
 
     const contourGroup = this.svg.select<SVGGElement>(
-      `.contour-group-${group}`
+      `.contour-group-${getCSSSafeName(group)}`
     );
 
     const gridData1D: number[] = [];
@@ -1391,7 +1394,7 @@ export class Embedding {
             const groupIndex = this.groupNames?.indexOf(group);
             this.showContours[groupIndex] = checked;
             this.svg
-              .select(`g.contour-group-${group}`)
+              .select(`g.contour-group-${getCSSSafeName(group)}`)
               .classed('hidden', !this.showContours[groupIndex]);
 
             if (this.showLabel) {
@@ -1531,3 +1534,11 @@ export class Embedding {
 
 const anyTrue = (items: boolean[]) => items.reduce((a, b) => a || b);
 const allTrue = (items: boolean[]) => items.reduce((a, b) => a && b);
+
+const getCSSSafeName = (name: string) => {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '');
+};

--- a/src/components/embedding/workers/tree.ts
+++ b/src/components/embedding/workers/tree.ts
@@ -1,11 +1,11 @@
-import d3 from '../../../utils/d3-import';
+import { config } from '../../../config/config';
 import type {
   PromptPoint,
-  UMAPPointStreamData,
-  TreeWorkerMessage
+  TreeWorkerMessage,
+  UMAPPointStreamData
 } from '../../../types/embedding-types';
+import d3 from '../../../utils/d3-import';
 import { timeit } from '../../../utils/utils';
-import { config } from '../../../config/config';
 
 const DEBUG = config.debug;
 
@@ -122,7 +122,6 @@ const initTimeQuadtrees = (
 const updateQuadtree = (points: PromptPoint[]) => {
   // Add these points to the quadtree after sending them to the main thread
   const allTree = groupTimeTreeMap.get(-1)!.get('')!;
-
   for (const point of points) {
     // Add the point to the tree containing all points
     allTree.add(point);


### PR DESCRIPTION
1. Fix group name issues https://github.com/poloclub/wizmap/issues/20
    1. Make sure the name used in CSS class is valid
2. Change default
    1. Show first group → show all groups 
