### PR TITLE
Minor fixes (escape html tags, stabilize tooltips, handle prefix join)

### DIFF
--- a/src/components/embedding/EmbeddingPointWebGL.ts
+++ b/src/components/embedding/EmbeddingPointWebGL.ts
@@ -575,10 +575,16 @@ export function highlightPoint(
           }
         }
 
+        // Sanitize text by replacing < and > with HTML-safe equivalents
+        const sanitizedText = text
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/&/g, '&amp;');
+
         this.hoverPoint.tooltip = `<div class="tooltip-json-container">
         ${imageHTML}
         <div class="tooltip-json-text">
-          ${text}
+          ${sanitizedText}
         </div>
       </div>`;
       } catch (e) {

--- a/src/components/embedding/EmbeddingPointWebGL.ts
+++ b/src/components/embedding/EmbeddingPointWebGL.ts
@@ -483,8 +483,9 @@ export function updateHighlightPoint(this: Embedding) {
   updatePopperTooltip(
     this.tooltipTop,
     oldHighlightPoint.node()! as unknown as HTMLElement,
-    this.hoverPoint.prompt,
-    'top'
+    this.hoverPoint.tooltip,
+    'top',
+    null
   );
 }
 

--- a/src/components/embedding/EmbeddingPointWebGL.ts
+++ b/src/components/embedding/EmbeddingPointWebGL.ts
@@ -4,7 +4,7 @@ import type {
   PromptPoint
 } from '../../types/embedding-types';
 import d3 from '../../utils/d3-import';
-import { rgbToHex, timeit } from '../../utils/utils';
+import { joinPath, rgbToHex, timeit } from '../../utils/utils';
 import type { Embedding } from './Embedding';
 import { updatePopperTooltip } from './EmbeddingLabel';
 import fragmentShader from './shaders/point.frag?raw';
@@ -545,7 +545,10 @@ export function highlightPoint(
   if (this.gridData?.image !== undefined) {
     if (this.gridData?.image.imageGroup == this.hoverPoint.groupID) {
       this.hoverPoint.tooltip = `<img class="tooltip-image"
-        src="${this.gridData?.image.imageURLPrefix + this.hoverPoint.prompt}"
+        src="${joinPath(
+          this.gridData?.image.imageURLPrefix || '',
+          this.hoverPoint.prompt
+        )}"
       >`;
     }
   }
@@ -570,9 +573,10 @@ export function highlightPoint(
           imageSrc = jsonData[imageKey];
           if (imageSrc) {
             imageHTML = `<div class="tooltip-image-container">
-          <img class="tooltip-image" src="${
-            (this.gridData?.jsonPoint.imageURLPrefix || '') + imageSrc
-          }"></div>`;
+          <img class="tooltip-image" src="${joinPath(
+            this.gridData?.jsonPoint.imageURLPrefix || '',
+            imageSrc
+          )}"></div>`;
           }
         }
 

--- a/src/components/floating-window/FloatingWindow.ts
+++ b/src/components/floating-window/FloatingWindow.ts
@@ -15,8 +15,7 @@ import type {
   HighlightedPromptPoint
 } from '../../types/embedding-types';
 import d3 from '../../utils/d3-import';
-import { getLatoTextWidth } from '../../utils/text-width';
-import { getContrastRatio, round } from '../../utils/utils';
+import { joinPath } from '../../utils/utils';
 
 interface FormattedSection {
   type: 'text' | 'image' | 'link';
@@ -127,7 +126,7 @@ export class FloatingWindow {
       gridData.image !== undefined &&
       gridData.image.imageGroup == point.groupID
     ) {
-      const imageURL = gridData.image.imageURLPrefix + point.prompt;
+      const imageURL = joinPath(gridData.image.imageURLPrefix, point.prompt);
       sections.push({
         type: 'image',
         header: 'Image',
@@ -153,7 +152,7 @@ export class FloatingWindow {
           gridData.jsonPoint.largeImageURLPrefix ||
           gridData.jsonPoint.imageURLPrefix;
         if (imageKey && imageURLPrefix) {
-          const image = imageURLPrefix + jsonData[imageKey];
+          const image = joinPath(imageURLPrefix, jsonData[imageKey]);
           sections.push({
             type: 'image',
             header: 'Image',

--- a/src/components/mapview/MapView.scss
+++ b/src/components/mapview/MapView.scss
@@ -44,7 +44,6 @@
   opacity: 1;
   transition: opacity 300ms ease-in-out;
   border-radius: $border-radius;
-
 }
 
 .popper-tooltip {

--- a/src/components/mapview/MapView.svelte
+++ b/src/components/mapview/MapView.svelte
@@ -9,8 +9,8 @@
   import SearchPanel from '../search-panel/SearchPanel.svelte';
 
   let component: HTMLElement | null = null;
-  // let datasetName = 'acl-abstracts';
-  let datasetName = 'temp';
+  let datasetName = 'acl-abstracts';
+  // let datasetName = 'temp';
   let dataURL: string | null = null;
   let gridURL: string | null = null;
   let notebookMode = false;

--- a/src/components/mapview/MapView.svelte
+++ b/src/components/mapview/MapView.svelte
@@ -9,8 +9,8 @@
   import SearchPanel from '../search-panel/SearchPanel.svelte';
 
   let component: HTMLElement | null = null;
-  let datasetName = 'acl-abstracts';
-  // let datasetName = 'temp';
+  // let datasetName = 'acl-abstracts';
+  let datasetName = 'temp';
   let dataURL: string | null = null;
   let gridURL: string | null = null;
   let notebookMode = false;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -345,3 +345,15 @@ export const yieldToMain = () => {
     setTimeout(resolve, 0);
   });
 };
+
+/**
+ * Joins two path segments, ensuring there is exactly one slash between them
+ * if segment1 does not already end with a slash.
+ */
+export const joinPath = (segment1: string, segment2: string) => {
+  if (segment1.endsWith('/')) {
+    return segment1 + segment2;
+  } else {
+    return segment1 + '/' + segment2;
+  }
+};


### PR DESCRIPTION
1. [Escape html tags in tooltip](https://github.com/poloclub/wizmap/commit/2ebce3450d3d6ff73c8c57334b8d6381994f5709)
2. [Make tooltip text consistent during zooming](https://github.com/poloclub/wizmap/commit/a740285c51818834a0b5d9c0c28793e29b8c3256)
3. [Handle prefix join logic to escape `//`](https://github.com/poloclub/wizmap/commit/2c75aa20d54e7c55e1b47a797a41700a6537aadd)